### PR TITLE
Updated solution for 6-kyu/consecutive-strings to Swift 5

### DIFF
--- a/6-kyu/consecutive-strings/swift/solution.swift
+++ b/6-kyu/consecutive-strings/swift/solution.swift
@@ -10,9 +10,8 @@ func longestConsec(_ strarr: [String], _ k: Int) -> String {
         }
         ret.append(str)
     }
-    if let result = ret.max(by: {$0.characters.count < $1.characters.count }) {
+    if let result = ret.max(by: {$0.count < $1.count }) {
         return result
-    } else {
-        return ""
     }
+    return ""
 }


### PR DESCRIPTION
Updated solution by removing references to `.characters`